### PR TITLE
ICC profile is obtained using uuid

### DIFF
--- a/jglfw/jni/glfw-3.0/src/cocoa_monitor.m
+++ b/jglfw/jni/glfw-3.0/src/cocoa_monitor.m
@@ -327,11 +327,9 @@ bool ProfileIterationCallback(CFDictionaryRef colorSyncDeviceProfileInfo, void *
 
 
     CFStringRef DeviceProfileURLKey = CFSTR("DeviceProfileURL");
-    CFStringRef DeviceDescription = CFSTR("DeviceDescription");
     CFStringRef DeviceProfileIsCurrentKey = CFSTR("DeviceProfileIsCurrent");
     CFStringRef DeviceClassKey = CFSTR("DeviceClass");
     CFStringRef MonitorDeviceClassValue = CFSTR("mntr");
-    CFStringRef DeviceProfileIsDefaultKey = CFSTR("DeviceProfileIsDefault");
 
     CFStringRef typeRef = (CFStringRef) CFDictionaryGetValue(colorSyncDeviceProfileInfo, DeviceClassKey);
     if (CFStringCompare(typeRef, MonitorDeviceClassValue, 0) != 0) {
@@ -345,17 +343,16 @@ bool ProfileIterationCallback(CFDictionaryRef colorSyncDeviceProfileInfo, void *
     }
 
     CFURLRef profilePath = (CFURLRef) CFDictionaryGetValue(colorSyncDeviceProfileInfo, DeviceProfileURLKey);
-    CFStringRef deviceName = (CFStringRef) CFDictionaryGetValue(colorSyncDeviceProfileInfo, DeviceDescription);
-    char* monitorName = monitor->name;
-    if (deviceName != NULL) {
-        char* utf8DeviceName = CFStringToUTF8String(deviceName);
-        if (!strcmp(monitorName, utf8DeviceName) && profilePath != NULL) {
-            const char* utf8ProfilePath = CFStringToUTF8String(CFURLGetString(profilePath));
-            monitor->iccProfilePath = strdup(utf8ProfilePath);
-            free(utf8ProfilePath);
-        }
-        free(utf8DeviceName);
-    }
+
+    CFUUIDRef uuid;
+	if (!CFDictionaryGetValueIfPresent(colorSyncDeviceProfileInfo, kColorSyncDeviceID, (const void**)&uuid))
+		goto cleanUp;
+
+	if (CFEqual(uuid, CGDisplayCreateUUIDFromDisplayID(monitor->ns.displayID))) {
+		const char* utf8ProfilePath = CFStringToUTF8String(CFURLGetString(profilePath));
+        monitor->iccProfilePath = strdup(utf8ProfilePath);
+        free(utf8ProfilePath);
+	}
 
 cleanUp:
     free(keysTypeRef);


### PR DESCRIPTION
This PR addresses the inabilty to get the ICC profile path for Macs with ARM.

ICC profile path was obtained correlating with monitor name.
However due to [CGDisplayIOServicePort](https://developer.apple.com/documentation/coregraphics/1543516-cgdisplayioserviceport?language=objc) being deprecated, it seems that Macs with ARM don't return anymore the monitor name, so the code return `Unknown`.
Consequently, when retrieving the ICC path and correlating with name, the path is not found.

This PR uses instead the uuid of the monitor obtined using the device id.
