### PR TITLE
Prevent virtual key release when NSApplication is NSApplicationAWT

### DIFF
--- a/jglfw/jni/glfw-3.0/src/cocoa_init.m
+++ b/jglfw/jni/glfw-3.0/src/cocoa_init.m
@@ -218,7 +218,19 @@ int _glfwPlatformInit(void)
                         "NSGL: Failed to locate OpenGL framework");
         return GL_FALSE;
     }
-	
+
+    NSEvent* (^block)(NSEvent*) = ^ NSEvent* (NSEvent* event)
+    {
+        if ([event modifierFlags] & NSEventModifierFlagCommand)
+            [[NSApp keyWindow] sendEvent:event];
+
+        return event;
+    };
+
+    _glfw.ns.keyUpMonitor =
+        [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp
+                                              handler:block];
+
 	createKeyTables();
 
 #if defined(_GLFW_USE_CHDIR)
@@ -261,6 +273,9 @@ void _glfwPlatformTerminate(void)
 
     // joysticks are not initialized
     // _glfwTerminateJoysticks();
+
+	if (_glfw.ns.keyUpMonitor)
+		[NSEvent removeMonitor:_glfw.ns.keyUpMonitor];
 
     _glfwTerminateContextAPI();
 }

--- a/jglfw/jni/glfw-3.0/src/cocoa_platform.h
+++ b/jglfw/jni/glfw-3.0/src/cocoa_platform.h
@@ -111,6 +111,7 @@ typedef struct _GLFWlibraryNS
 
     CGEventSourceRef eventSource;
     id              delegate;
+    id              keyUpMonitor;
 
     char*           clipboardString;
 


### PR DESCRIPTION
We discovered that current JDKs apply the `sendKey` events already.
So, there's no need to generates a virtual one in that case.